### PR TITLE
Add revoke statement for user_lookup function readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ BEGIN
 END;
 $$;
 
+REVOKE ALL ON FUNCTION "user_lookup"("i_username" "text", OUT "uname" "text", OUT "phash" "text") FROM PUBLIC;
 GRANT ALL ON FUNCTION "user_lookup"("i_username" "text", OUT "uname" "text", OUT "phash" "text") TO "pgbouncer";
 ```
 


### PR DESCRIPTION
It seems it is better to execute REVOKE before grant permissions to pgbouncer, so I added this statement to readme. 

https://blog.2ndquadrant.com/pg-phriday-securing-pgbouncer/
https://www.cybertec-postgresql.com/en/pgbouncer-authentication-made-easy/